### PR TITLE
Thaumcraft - Runic Matrix and Thaumometer overwork

### DIFF
--- a/scripts/expert/Thaumcraft.zs
+++ b/scripts/expert/Thaumcraft.zs
@@ -50,7 +50,7 @@ mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("TALLOW", "HEDGEALCHEMY@1",
 
 # -Thaumometer
 recipes.remove(<thaumcraft:thaumometer>);
-recipes.addShaped(<thaumcraft:thaumometer>, [[null, <thaumcraft:crystal_essence>, null], [<ore:ingotGold>, <botania:managlass>, <ore:ingotGold>], [null, <thaumcraft:crystal_essence>, null]]);
+recipes.addShaped(<thaumcraft:thaumometer>, [[null, <thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "aer"}]}), null], [<ore:ingotGold>, <botania:managlass>, <ore:ingotGold>], [null, <thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "aer"}]}), null]]);
 
 # -Goggles of Revealing
 mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumcraft:goggles>);

--- a/scripts/expert/Thaumcraft.zs
+++ b/scripts/expert/Thaumcraft.zs
@@ -25,7 +25,7 @@ mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("PAVETRAVEL", "PAVINGSTONES
 
 # -Runic Matrix
 mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumcraft:infusion_matrix>);
-mods.botania.RuneAltar.addRecipe(<thaumcraft:infusion_matrix>, [<bewitchment:waystone>, <bloodmagic:blood_rune>, <bloodmagic:blood_rune>, <bloodmagic:blood_rune>, <bloodmagic:blood_rune>, <ore:runeWaterB>, <ore:runeFireB>, <ore:runeEarthB>, <ore:runeAirB>, <ore:runeManaB>], 1000000);
+mods.thaumcraft.ArcaneWorkbench.registerShapedRecipe("RunicMatrix", "INFUSION@2", 64, [<aspect:aer> * 64, <aspect:terra> * 64, <aspect:ignis> * 64, <aspect:ordo> * 64, <aspect: aqua> * 64, <aspect:perditio> * 64], <thaumcraft:infusion_matrix>, [[<bloodmagic:blood_rune>, <botania:rune:3>, <bloodmagic:blood_rune>], [<botania:rune>, <bewitchment:waystone>, <botania:rune:2>], [<bloodmagic:blood_rune>, <botania:rune:1>, <bloodmagic:blood_rune>]]);
 
 # -Mirrored Glass
 mods.thaumcraft.ArcaneWorkbench.removeRecipe(<thaumcraft:mirrored_glass>);


### PR DESCRIPTION
**Runic Matrix:**

The old recipe was made with Botania which cannot be registered as crafting by Thaumcraft and as a result the research cannot be completed.

Added recipe in the Arcane Workbench to continue research.

**Thaumometer:**

Thaumcraft Crystals were created with NBT tags so you can't use OreDict to use any Crystal for the recipe.

The recipe has now been changed to AER Crystal only to avoid problems with crafting and JEI