### PR TITLE
Nuclear Reactor explodes now

### DIFF
--- a/config/IC2.ini
+++ b/config/IC2.ini
@@ -120,7 +120,7 @@ wrenchLogging = true
 ; Maximum Explosion power of a nuke, where TNT is 4.
 nukeExplosionPowerLimit = 0
 ; Maximum explosion power of a nuclear reactor, where TNT is 4.
-reactorExplosionPowerLimit = 0
+reactorExplosionPowerLimit = 45
 ; Enable the nuke
 enableNuke = false
 


### PR DESCRIPTION
The Reactor cannot explode in the current version - this has now been reset to its default value, so it can explode again.