### PR TITLE
Buildcraft Iridium Ore Power Rework

### DIFF
--- a/scripts/expert/Buildcraft.zs
+++ b/scripts/expert/Buildcraft.zs
@@ -45,6 +45,6 @@ AssemblyTable.addRecipe("WoodToCopperChestUpgrade", <ironchest:wood_copper_chest
 AssemblyTable.addRecipe("DiamondToObsidianChestUpgrade", <ironchest:diamond_obsidian_chest_upgrade>, 80000, [<minecraft:diamond>, <minecraft:obsidian> * 8]);
 
 #IridiumOre
-AssemblyTable.addRecipe("IridiumOre", <ic2:misc_resource:1>, 80000000, [<ic2:nuclear:4>, <ic2:nuclear:10>]);
+AssemblyTable.addRecipe("IridiumOre", <ic2:misc_resource:1>, 10000000, [<ic2:nuclear:4>, <ic2:nuclear:10>]);
 
 print("Initialized 'Buildcraft.zs'");


### PR DESCRIPTION
Changed the Value from 80000000MJ to 10000000MJ