### PR TITLE
Added Unstable Tools Recipe for Unstable Ingots and Division Sigils

### DIFF
--- a/scripts/expert/ExtraUtilites2.zs
+++ b/scripts/expert/ExtraUtilites2.zs
@@ -5,6 +5,9 @@
 
 print("Initializing 'ExtraUtilites2.zs'...");
 
+#Creative Builders Wand
+recipes.addShaped(<extrautils2:itemcreativebuilderswand>, [[null, null, <unstabletools:pseudo_unstable_ingot>], [null, <extrautils2:decorativesolidwood:1>, null], [<extrautils2:decorativesolidwood:1>, null, null]]);
+
 #Watering Can
 recipes.remove(<extrautils2:wateringcan:*>);
 recipes.addShaped(<extrautils2:wateringcan>, [[<ore:ingotSteel>, <minecraft:dye:15>, <harvestcraft:beetseeditem>],  [<ore:ingotSteel>, <minecraft:bowl>, <ore:ingotSteel>], [<harvestcraft:kiwiseeditem>, <ore:ingotSteel>, <harvestcraft:cornseeditem>]]);

--- a/scripts/expert/UnstableTools.zs
+++ b/scripts/expert/UnstableTools.zs
@@ -1,0 +1,47 @@
+#Name: UnstableTools.zs
+#Author: Sander
+#Modpack: Infinity Evolved Reloaded
+#packmode expert
+
+print("Initializing 'UnstableTools.zs'...");
+
+var DisabledDivisionSigil = <unstabletools:division_sign>.withTag({activated: 0 as byte});
+var ActivatedDivisionSigil = <unstabletools:division_sign>.onlyWithTag({activated: 1 as byte});
+var PseudoDivisionSigil = <unstabletools:division_sign>.withTag({stable: 1 as byte});
+var DivisionSigilUsesLeft = <unstabletools:division_sign>.withTag({d: 1000 as long, activated: 1 as byte});
+
+#-------------------------------------------------------------------------------------------------------------------------
+
+#Disabled Division Sigil
+recipes.removeByRecipeName("unstabletools:unstable_ingot");
+
+#Activated Division Sigil
+recipes.addShaped(DivisionSigilUsesLeft, [
+    [<minecraft:redstone>, <enderio:item_soul_vial:1>.withTag({entityId: "minecraft:chicken"}), <minecraft:redstone>], 
+    [<minecraft:redstone>, DisabledDivisionSigil, <minecraft:redstone>], 
+    [<minecraft:redstone>, <minecraft:enchanting_table>.reuse(), <minecraft:redstone>]
+    ]);
+
+#Unstable Ingot - 200ticks
+recipes.addShaped("UnstableIngot", <unstabletools:unstable_ingot>.withTag({timer: 200 as long}), [
+    [null, <minecraft:iron_ingot>, null], 
+    [null, ActivatedDivisionSigil, null], 
+    [null, <minecraft:diamond>, null]
+    ]);
+
+#Pseudo Division Sigil
+recipes.removeByRecipeName("unstabletools:advanced_division_sign");
+recipes.addShaped(PseudoDivisionSigil, [
+    [<minecraft:totem_of_undying>, <minecraft:elytra>.anyDamage(), <minecraft:clay>], 
+    [<unstabletools:unstable_block>, DisabledDivisionSigil, <unstabletools:unstable_block>], 
+    [<minecraft:dragon_breath>, <minecraft:chorus_flower>, <minecraft:nether_star>]
+    ]);
+
+#Unstable Ingot - Stable
+recipes.addShaped("UnstableIngotStable", <unstabletools:pseudo_unstable_ingot>, [
+    [null, <minecraft:iron_ingot>, null], 
+    [null, PseudoDivisionSigil, null], 
+    [null, <minecraft:diamond>, null]
+    ]);
+
+print("Initialized 'UnstableTools.zs'");

--- a/scripts/normal/ExtraUtilities2.zs
+++ b/scripts/normal/ExtraUtilities2.zs
@@ -9,4 +9,7 @@ print("Initializing 'ExtraUtilities2.zs'...");
 # -ExtraUtilities2 Unstable Ingot
 mods.jei.JEI.hide(<extrautils2:unstableingots>);
 
+#Creative Builders Wand
+recipes.addShaped(<extrautils2:itemcreativebuilderswand>, [[null, null, <unstabletools:pseudo_unstable_ingot>], [null, <extrautils2:decorativesolidwood:1>, null], [<extrautils2:decorativesolidwood:1>, null, null]]);
+
 print("Initialized 'ExtraUtilities2.zs'");

--- a/scripts/normal/UnstableTools.zs
+++ b/scripts/normal/UnstableTools.zs
@@ -1,0 +1,47 @@
+#Name: UnstableTools.zs
+#Author: Sander
+#Modpack: Infinity Evolved Reloaded
+#packmode normal
+
+print("Initializing 'UnstableTools.zs'...");
+
+var DisabledDivisionSigil = <unstabletools:division_sign>.withTag({activated: 0 as byte});
+var ActivatedDivisionSigil = <unstabletools:division_sign>.onlyWithTag({activated: 1 as byte});
+var PseudoDivisionSigil = <unstabletools:division_sign>.withTag({stable: 1 as byte});
+var DivisionSigilUsesLeft = <unstabletools:division_sign>.withTag({d: 1000 as long, activated: 1 as byte});
+
+#-------------------------------------------------------------------------------------------------------------------------
+
+#Disabled Division Sigil
+recipes.removeByRecipeName("unstabletools:unstable_ingot");
+
+#Activated Division Sigil
+recipes.addShaped(DivisionSigilUsesLeft, [
+    [<minecraft:redstone>, <enderio:item_soul_vial:1>.withTag({entityId: "minecraft:chicken"}), <minecraft:redstone>], 
+    [<minecraft:redstone>, DisabledDivisionSigil, <minecraft:redstone>], 
+    [<minecraft:redstone>, <minecraft:enchanting_table>.reuse(), <minecraft:redstone>]
+    ]);
+
+#Unstable Ingot - 200ticks
+recipes.addShaped("UnstableIngot", <unstabletools:unstable_ingot>.withTag({timer: 200 as long}), [
+    [null, <minecraft:iron_ingot>, null], 
+    [null, ActivatedDivisionSigil, null], 
+    [null, <minecraft:diamond>, null]
+    ]);
+
+#Pseudo Division Sigil
+recipes.removeByRecipeName("unstabletools:advanced_division_sign");
+recipes.addShaped(PseudoDivisionSigil, [
+    [<minecraft:totem_of_undying>, <minecraft:elytra>.anyDamage(), <minecraft:clay>], 
+    [<unstabletools:unstable_block>, DisabledDivisionSigil, <unstabletools:unstable_block>], 
+    [<minecraft:dragon_breath>, <minecraft:chorus_flower>, <minecraft:nether_star>]
+    ]);
+
+#Unstable Ingot - Stable
+recipes.addShaped("UnstableIngotStable", <unstabletools:pseudo_unstable_ingot>, [
+    [null, <minecraft:iron_ingot>, null], 
+    [null, PseudoDivisionSigil, null], 
+    [null, <minecraft:diamond>, null]
+    ]);
+
+print("Initialized 'UnstableTools.zs'");


### PR DESCRIPTION
**Recipes Added:**
 - Division Sigil (Disabled)
 - Division Sigil (Activated)
 - Division Sigil (Pseudo)
 - Unstable Ingot (Explode)
 - Unstable Ingot (Stable)

Unstable Tools recipes do not work properly, so new ones have been created for Expert Mode so that you can work with these.
