### PR TITLE
Blood Magic Recipe Changes and Additions

### DIFF
--- a/scripts/expert/BloodMagic.zs
+++ b/scripts/expert/BloodMagic.zs
@@ -115,4 +115,8 @@ mods.bloodmagic.BloodAltar.addRecipe(<bloodmagic:blood_orb>.withTag({orb: "blood
 #Crystal Cluster
 mods.thaumcraft.Infusion.registerRecipe("CrystalClusterBlock", "", <bloodmagic:decorative_brick:2>, 5, [<aspect:permutatio> * 64, <aspect:praecantatio> * 64, <aspect:fabrico> * 64, <aspect:spiritus> * 64], <bloodmagic:decorative_brick>, [<bloodmagic:slate>, <bloodmagic:slate>, <bloodmagic:slate:1>, <bloodmagic:slate:1>, <bloodmagic:item_demon_crystal:1>, <bloodmagic:item_demon_crystal:1>, <botania:manaresource:14>, <botania:manaresource:14>]);
 
+#Demon Blood Shard
+var soulcontainer = <bloodmagic:soul_gem:2>.withTag({souls: 1024.0});
+mods.bloodmagic.AlchemyTable.addRecipe(<bloodmagic:blood_shard:1>, [<bloodmagic:blood_shard>, <bloodmagic:item_demon_crystal>, soulcontainer], 20000, 100, 3);
+
 print("Initialized 'bloodmagic.zs'");

--- a/scripts/expert/BloodMagic.zs
+++ b/scripts/expert/BloodMagic.zs
@@ -32,7 +32,7 @@ recipes.addShaped(<bloodmagic:teleposer>, [[<ore:ingotGold>, <ore:ingotGold>, <o
 mods.bloodmagic.BloodAltar.removeRecipe(<minecraft:ender_pearl>);
 mods.bloodmagic.BloodAltar.addRecipe(<bloodmagic:teleposition_focus>, <botania:manaresource:1>, 4, 2000, 10, 10);
 mods.bloodmagic.BloodAltar.removeRecipe(<bloodmagic:teleposition_focus>);
-mods.bloodmagic.BloodAltar.addRecipe(<bloodmagic:teleposition_focus:1>, <minecraft:nether_star>, 4, 10000, 10, 10);
+mods.bloodmagic.BloodAltar.addRecipe(<bloodmagic:teleposition_focus:1>, <minecraft:nether_star>, 3, 10000, 10, 10);
 
 # -Runes
 recipes.remove(<bloodmagic:blood_rune>);

--- a/scripts/expert/BloodMagic.zs
+++ b/scripts/expert/BloodMagic.zs
@@ -31,7 +31,7 @@ recipes.remove(<bloodmagic:teleposer>);
 recipes.addShaped(<bloodmagic:teleposer>, [[<ore:ingotGold>, <ore:ingotGold>, <ore:ingotGold>], [<botania:manaresource:1>, <bloodmagic:teleposition_focus>, <botania:manaresource:1>], [<ore:ingotGold>, <ore:ingotGold>, <ore:ingotGold>]]);
 mods.bloodmagic.BloodAltar.removeRecipe(<minecraft:ender_pearl>);
 mods.bloodmagic.BloodAltar.addRecipe(<bloodmagic:teleposition_focus>, <botania:manaresource:1>, 4, 2000, 10, 10);
-mods.bloodmagic.BloodAltar.removeRecipe(<bloodmagic:teleposition_focus:1>);
+mods.bloodmagic.BloodAltar.removeRecipe(<bloodmagic:teleposition_focus>);
 mods.bloodmagic.BloodAltar.addRecipe(<bloodmagic:teleposition_focus:1>, <minecraft:nether_star>, 4, 10000, 10, 10);
 
 # -Runes


### PR DESCRIPTION
**Added:**
 - Demon Blood Shard 

**Fixed:**
 - Removed default Teleposer Recipe from Blood Altar
 - Changed the Tier Level from Enhanced Teleposition Focus from 5 to 4