### PR TITLE
Fixed uncraftable Gaia Pylon

### DIFF
--- a/scripts/expert/Botania.zs
+++ b/scripts/expert/Botania.zs
@@ -2,6 +2,7 @@
 #Author: Sander
 #Modpack: Infinity Evolved Reloaded
 #packmode expert
+import mods.thaumcraft.Infusion;
 
 print("Initializing 'botania.zs'...");
 
@@ -60,7 +61,7 @@ recipes.addShaped(<botania:pylon>, [[<ore:nuggetGold>, <ore:ingotGold>, <ore:nug
 recipes.remove(<botania:pylon:1>);
 recipes.addShaped(<botania:pylon:1>, [[<ore:nuggetManasteel>, <bewitchment:otherworldly_tears>, <ore:nuggetManasteel>], [<botania:manaresource:4>, <botania:pylon>, <botania:manaresource:4>], [<ore:nuggetManasteel>, <ore:pearlEnderEye>, <ore:nuggetManasteel>]]);
 recipes.remove(<botania:pylon:2>);
-mods.thaumcraft.Infusion.registerRecipe("Research", "Pylons", <botania:pylon:1>, 20, [<aspect:praecantatio>, <aspect:fabrico>, <aspect:metallum>, <aspect:motus>], <botania:manaresource:9>, [<botania:manaresource:7>, <bloodmagic:slate:4>, <botania:manaresource:7>, <botania:manaresource:8>, <botania:manaresource:7>, <bloodmagic:slate:4>, <botania:manaresource:7>]);
+mods.thaumcraft.Infusion.registerRecipe("GaiaPylon", "", <botania:pylon:2>, 6, [<aspect:praecantatio> * 32, <aspect:fabrico> * 32, <aspect:metallum> * 32, <aspect:motus> * 32], <botania:manaresource:9>, [<botania:manaresource:7>, <bloodmagic:slate:4>, <botania:manaresource:7>, <botania:manaresource:8>, <botania:manaresource:7>, <bloodmagic:slate:4>, <botania:manaresource:7>]);
 
 # -Catalysts
 recipes.remove(<botania:alchemycatalyst>);


### PR DESCRIPTION
**Fixed:**
- Imported Thaumcraft Infusion Package
- Removed not existing Research from Recipe
- Added 32 Aspect each of Praecantatio, Fabrico, Metallum and Motus
- Renamed String Name for better clarification
- Changed the ItemStack Output from Natua Pylon to Gaia Pylon
- Changed the Instability to 6 (20 before) 
    - (10 to 11 is one of the highest instability - Creative Mana Pool has 10)