### PR TITLE
Fixing Resonant Conversion Kit, added the default Deep Dark Portale Recipe for both Modes and Removed the Void Metal Ingot Recipe from Arc Furnace

### DIFF
--- a/scripts/expert/ExtraUtilites2.zs
+++ b/scripts/expert/ExtraUtilites2.zs
@@ -12,10 +12,14 @@ recipes.addShaped(<extrautils2:itemcreativebuilderswand>, [[null, null, <unstabl
 recipes.remove(<extrautils2:wateringcan:*>);
 recipes.addShaped(<extrautils2:wateringcan>, [[<ore:ingotSteel>, <minecraft:dye:15>, <harvestcraft:beetseeditem>],  [<ore:ingotSteel>, <minecraft:bowl>, <ore:ingotSteel>], [<harvestcraft:kiwiseeditem>, <ore:ingotSteel>, <harvestcraft:cornseeditem>]]);
 
-#Deep Dark Portal
+#Bedrock Portal
 recipes.remove(<extrautils2:teleporter:1>);
-recipes.addShaped(<extrautils2:teleporter:1>, [[<extrautils2:compressedcobblestone:2>, <extrautils2:compressedcobblestone:2>, <extrautils2:compressedcobblestone:2>], [<extrautils2:compressedcobblestone:2>, null, <extrautils2:compressedcobblestone:2>], [<extrautils2:compressedcobblestone:2>, <extrautils2:compressedcobblestone:2>, <extrautils2:compressedcobblestone:2>]]);
-
+recipes.addShaped(<extrautils2:teleporter:1>, 
+[
+    [<extrautils2:compressedcobblestone:3>, <unstabletools:unstable_ingot>, <extrautils2:compressedcobblestone:3>], 
+    [<unstabletools:unstable_ingot>, <extrautils2:compressedcobblestone:4>, <unstabletools:unstable_ingot>], 
+    [<extrautils2:compressedcobblestone:3>, <unstabletools:unstable_ingot>, <extrautils2:compressedcobblestone:3>]
+]);
 #Generators
 recipes.remove(<extrautils2:machine>.withTag({Type: "extrautils2:generator_enchant"}));
 recipes.remove(<extrautils2:machine>.withTag({Type: "extrautils2:generator_potion"}));

--- a/scripts/expert/Thaumcraft.zs
+++ b/scripts/expert/Thaumcraft.zs
@@ -137,4 +137,7 @@ recipes.addShaped(<thaumcraft:crystal_ordo>, [[<thaumcraft:crystal_essence>.with
 mods.thaumcraft.Infusion.removeRecipe(<thaumcraft:crystal_perditio>);
 recipes.addShaped(<thaumcraft:crystal_perditio>, [[<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "perditio"}]}), <thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "perditio"}]}), <thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "perditio"}]})], [<thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "perditio"}]}), <thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "perditio"}]}), <thaumcraft:crystal_essence>.withTag({Aspects: [{amount: 1, key: "perditio"}]})], [null, null, null]]);
 
+#Void Metal Ingot Removal from Arc Furnace
+mods.immersiveengineering.ArcFurnace.removeRecipe(<thaumcraft:ingot:1>);
+
 print("Initialized 'Thaumcraft.zs'");

--- a/scripts/expert/ThermalExpansion.zs
+++ b/scripts/expert/ThermalExpansion.zs
@@ -102,7 +102,7 @@ AssemblyTable.addRecipe("ReinforcedConversionKit", <thermalfoundation:upgrade:33
 AssemblyTable.addRecipe("SignalumConversionKit", <thermalfoundation:upgrade:34>, 135000, [<thermalfoundation:upgrade>, <thermalfoundation:upgrade:1>, <thermalfoundation:upgrade:2>]);
 
 # ---Resonant
-AssemblyTable.addRecipe("ResonantConversionKit", <thermalfoundation:upgrade:35>, 220000, [<thermalfoundation:upgrade>, <thermalfoundation:upgrade:1>, <thermalfoundation:upgrade:2>, <thermalfoundation:upgrade:3>]);
+AssemblyTable.addRecipe("ResonantConversionKit", <thermalfoundation:upgrade:35>, 220000, [<thermalfoundation:upgrade:34>, <thermalfoundation:upgrade:3>]);
 
 #Induction Smelter
 recipes.remove(<thermalexpansion:machine:3>.withTag({RSControl: 0 as byte, Facing: 3 as byte, Energy: 0, SideCache: [3, 1, 2, 2, 2, 2] as byte[] as byte[], Level: 0 as byte}));

--- a/scripts/normal/ExtraUtilities2.zs
+++ b/scripts/normal/ExtraUtilities2.zs
@@ -12,4 +12,13 @@ mods.jei.JEI.hide(<extrautils2:unstableingots>);
 #Creative Builders Wand
 recipes.addShaped(<extrautils2:itemcreativebuilderswand>, [[null, null, <unstabletools:pseudo_unstable_ingot>], [null, <extrautils2:decorativesolidwood:1>, null], [<extrautils2:decorativesolidwood:1>, null, null]]);
 
+#Bedrock Portal
+recipes.remove(<extrautils2:teleporter:1>);
+recipes.addShaped(<extrautils2:teleporter:1>, 
+[
+    [<extrautils2:compressedcobblestone:3>, <unstabletools:unstable_ingot>, <extrautils2:compressedcobblestone:3>], 
+    [<unstabletools:unstable_ingot>, <extrautils2:compressedcobblestone:4>, <unstabletools:unstable_ingot>], 
+    [<extrautils2:compressedcobblestone:3>, <unstabletools:unstable_ingot>, <extrautils2:compressedcobblestone:3>]
+]);
+
 print("Initialized 'ExtraUtilities2.zs'");


### PR DESCRIPTION
**Added:**
 - Default Deep Dark Portale Recipe for both modes

**Fixed:**
 - Resonant Conversion kit is now craftable in the Assembly Table