### PR TITLE
Fixed Simply Jetpacks Thermal Expansion progression

### DIFF
--- a/scripts/expert/Redstonearsenal.zs
+++ b/scripts/expert/Redstonearsenal.zs
@@ -7,19 +7,4 @@ print("Initializing 'RedstoneArsenal.zs'...");
 
 #Fluxplating
 recipes.remove(<redstonearsenal:material:224>);
-recipes.remove(<simplyjetpacks:metaitemmods:16>);
 recipes.addShaped(<redstonearsenal:material:224>, [[<redstonearsenal:material:64>,<redstonearsenal:material:64>,<redstonearsenal:material:64>], [<redstonearsenal:material:160>, <redstonearsenal:material:128>, <redstonearsenal:material:160>], [<redstonearsenal:material:64>,<redstonearsenal:material:64>,<redstonearsenal:material:64>]]);
-
-#Flux Infused-Jetpack
-recipes.remove(<simplyjetpacks:itemjetpack:18>);
-recipes.addShaped(<simplyjetpacks:itemjetpack:18>, [[<redstonearsenal:material:224>, <redstonearsenal:armor.plate_flux>, <redstonearsenal:material:224>], [<simplyjetpacks:metaitemmods:21>, <simplyjetpacks:itemjetpack:17>, <simplyjetpacks:metaitemmods:21>], [<simplyjetpacks:metaitemmods:30>, <simplyjetpacks:itemfluxpack:10>, <simplyjetpacks:metaitemmods:30>]]);
-
-#Cryotheum Coolant Unit Empty
-recipes.remove(<simplyjetpacks:metaitemmods:20>);
-recipes.addShaped(<simplyjetpacks:metaitemmods:20>, [[<redstonearsenal:material:32>, <ore:ingotTin>, <redstonearsenal:material:32>], [<ore:ingotTin>, <thermalfoundation:glass:3>, <ore:ingotTin>], [<redstonearsenal:material:32>, <ore:ingotTin>, <redstonearsenal:material:32>]]);
-
-#Flux Thruster
-recipes.remove(<simplyjetpacks:metaitemmods:30>);
-recipes.addShaped(<simplyjetpacks:metaitemmods:30>, [[<redstonearsenal:material:32>, <redstonearsenal:material:224>, <redstonearsenal:material:32>], [<simplyjetpacks:metaitemmods:19>, <simplyjetpacks:metaitemmods:29>, <simplyjetpacks:metaitemmods:19>], [null, null, null]]);
-
-print("Initialized 'RedstonAarsenal.zs'");

--- a/scripts/expert/SimplyJetpacks.zs
+++ b/scripts/expert/SimplyJetpacks.zs
@@ -3,13 +3,76 @@
 #Modpack: Infinity Evolved Reloaded
 #packmode expert
 
+import mods.jei.JEI;
+
 print("Initializing 'SimplyJetpacks.zs'...");
 
-#Replace Truster with Different TE dynamos
-recipes.remove(<simplyjetpacks:metaitemmods:28>);
-recipes.addShaped(<simplyjetpacks:metaitemmods:28>, [[<ore:ingotElectrum>, <thermalfoundation:material:515>, <ore:ingotElectrum>], [<thermaldynamics:duct_0:2>, <thermalexpansion:dynamo:3>, <thermaldynamics:duct_0:2>], [<ore:ingotElectrum>, <forge:bucketfilled>.withTag({FluidName: "redstone", Amount: 1000}), <ore:ingotElectrum>]]);
+// Items
+var ironArmorPlating = <simplyjetpacks:metaitemmods:16>;
+var bronzeArmorPlating = <simplyjetpacks:metaitemmods:17>;
+var invarArmorPlating = <simplyjetpacks:metaitemmods:18>;
+var resonantArmorPlating = <simplyjetpacks:metaitemmods:19>;
 
-recipes.remove(<simplyjetpacks:metaitemmods:27>);
-recipes.addShaped(<simplyjetpacks:metaitemmods:27>, [[<ore:ingotInvar>, <thermalfoundation:material:513>, <ore:ingotInvar>], [<thermaldynamics:duct_0:1>, <thermalexpansion:dynamo:3>, <thermaldynamics:duct_0:1>], [<ore:ingotInvar>, <ore:dustRedstone>, <ore:ingotInvar>]]);
+var leadstoneThruster = <simplyjetpacks:metaitemmods:20>;
+var hardenedThruster = <simplyjetpacks:metaitemmods:21>;
+var reinforcedThruster = <simplyjetpacks:metaitemmods:22>;
+var resonantThruster = <simplyjetpacks:metaitemmods:23>;
+
+var fluxedThruster = <simplyjetpacks:metaitemmods:24>;
+var fluxInfusedChestplate = <simplyjetpacks:itemjetpack:24>;
+
+var fluxInfusedChestplateAssembly = <simplyjetpacks:metaitemmods:25>;
+var fluxedArmorPlating = <simplyjetpacks:metaitemmods:26>;
+
+var armoredResonantJetpack = <simplyjetpacks:itemjetpack:23>;
+var armoredResonantFluxpack = <simplyjetpacks:itemfluxpack:14>;
+
+var cryotheumCoolantUnit = <simplyjetpacks:metaitemmods:30>;
+var glowstoneElevationUnit = <simplyjetpacks:metaitemmods:28>;
+
+// For some reason these items don't show up in JEI by default
+JEI.addItem(leadstoneThruster);
+JEI.addItem(hardenedThruster);
+JEI.addItem(reinforcedThruster);
+JEI.addItem(resonantThruster);
+JEI.addItem(ironArmorPlating);
+JEI.addItem(bronzeArmorPlating);
+JEI.addItem(invarArmorPlating);
+JEI.addItem(resonantArmorPlating);
+
+// Replace Truster with Different TE dynamos
+recipes.remove(reinforcedThruster);
+recipes.addShaped(reinforcedThruster, [
+    [<ore:ingotElectrum>, <thermalfoundation:material:515>, <ore:ingotElectrum>],
+    [<thermaldynamics:duct_0:2>, <thermalexpansion:dynamo:3>, <thermaldynamics:duct_0:2>],
+    [<ore:ingotElectrum>, <forge:bucketfilled>.withTag({FluidName: "redstone", Amount: 1000}), <ore:ingotElectrum>]
+]);
+
+recipes.remove(hardenedThruster);
+recipes.addShaped(hardenedThruster, [
+    [<ore:ingotInvar>, <thermalfoundation:material:513>, <ore:ingotInvar>],
+    [<thermaldynamics:duct_0:1>, <thermalexpansion:dynamo:3>, <thermaldynamics:duct_0:1>],
+    [<ore:ingotInvar>, <ore:dustRedstone>, <ore:ingotInvar>]
+]);
+
+// Remove armor and plates provided by Redstone Arsenal
+JEI.removeAndHide(fluxedArmorPlating);
+JEI.removeAndHide(fluxInfusedChestplateAssembly);
+
+// Flux-Infused Jetplate
+recipes.remove(fluxInfusedChestplate);
+recipes.addShaped(fluxInfusedChestplate, [
+    [<redstonearsenal:material:224>, <redstonearsenal:armor.plate_flux>, <redstonearsenal:material:224>],
+    [cryotheumCoolantUnit, armoredResonantJetpack, cryotheumCoolantUnit],
+    [fluxedThruster, armoredResonantFluxpack, fluxedThruster]
+]);
+
+// Fluxed Thrusters
+recipes.remove(fluxedThruster);
+recipes.addShaped(fluxedThruster, [
+    [<redstonearsenal:material:32>, <redstonearsenal:material:224>, <redstonearsenal:material:32>],
+    [glowstoneElevationUnit, resonantThruster, glowstoneElevationUnit],
+    [null, null, null]
+]);
 
 print("Initialized 'SimplyJetpacks.zs'");


### PR DESCRIPTION
### Fixed recipes for 
- Leadstone thrusters
- Hardened thrusters
- Reinforced thrusters
- Fluxed thrusters
- Flux-Infused JetPlates

Brought up a few missing items in JEI
Also removed fluxed platings from simplyjetpacks in favor of redstone arsenal ones

Dunno 'bout jetpack quests, but other than that this one closes #141 (someone should fix them, and since vanilla jetpacks are going away as for #143, they become completely wrong in expert mode)

_P.S. Yep, it's me ❄ C̴̪̎h̵͎̆e̴̝͆e̷̺͐š̵͉e̷̞̍ ❄#9901_