### PR TITLE
Reworked MinecraftGettingStarted.zs

### DIFF
--- a/config/enderio/recipes/user/user_recipes.xml
+++ b/config/enderio/recipes/user/user_recipes.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <enderio:recipes xmlns:enderio="http://enderio.com/recipes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://enderio.com/recipes recipes.xsd ">
+    <recipe name="Tweak: Stick from Wood" required="false" disabled="true">
+    </recipe>
 
+    <recipe name="Tweak: Chest from Wood" required="false" disabled="true">
+    </recipe>
 </enderio:recipes>

--- a/scripts/expert/MinecraftGettingStarted.zs
+++ b/scripts/expert/MinecraftGettingStarted.zs
@@ -2,220 +2,317 @@
 #Author: Sander
 #Modpack: Infinity Evolved Reloaded
 #packmode expert
-
+import crafttweaker.item.IItemStack as IItemStack;
 print("Initializing 'MinecraftGettingStarted.zs'...");
 
-#Wood Nerf
-recipes.remove(<minecraft:planks:1>);
-recipes.remove(<minecraft:planks:2>);
-recipes.remove(<minecraft:planks:3>);
-recipes.remove(<minecraft:planks:4>);
-recipes.remove(<minecraft:planks:5>);
-recipes.remove(<minecraft:planks>);
-recipes.remove(<bewitchment:cypress_planks>);
-recipes.remove(<bewitchment:elder_planks>);
-recipes.remove(<bewitchment:dragons_blood_planks>);
-recipes.remove(<biomesoplenty:planks_0:8>);
-recipes.remove(<biomesoplenty:planks_0:3>);
-recipes.remove(<biomesoplenty:planks_0:11>);
-recipes.remove(<forestry:planks.0:12>);
-recipes.remove(<natura:overworld_planks:5>);
-recipes.remove(<biomesoplenty:planks_0:14>);
-recipes.remove(<biomesoplenty:planks_0:2>);
-recipes.remove(<forestry:planks.1:2>);
-recipes.remove(<biomesoplenty:planks_0:1>);
-recipes.remove(<biomesoplenty:planks_0>);
-recipes.remove(<forestry:planks.1:4>);
-recipes.remove(<forestry:planks.0:10>);
-recipes.remove(<biomesoplenty:planks_0:12>);
-recipes.remove(<biomesoplenty:planks_0:6>);
-recipes.remove(<biomesoplenty:planks_0:5>);
-recipes.remove(<biomesoplenty:planks_0:4>);
-recipes.remove(<twilightforest:mine_planks>);
-recipes.remove(<twilightforest:sort_planks>);
-recipes.remove(<twilightforest:twilight_oak_planks>);
-recipes.remove(<twilightforest:time_planks>);
-recipes.remove(<twilightforest:canopy_planks>);
-recipes.remove(<twilightforest:trans_planks>);
-recipes.remove(<twilightforest:mangrove_planks>);
-recipes.remove(<twilightforest:dark_planks>);
-recipes.remove(<forestry:planks.fireproof.1:11>);
-recipes.remove(<forestry:planks.vanilla.fireproof.0:5>);
-recipes.remove(<forestry:planks.vanilla.fireproof.0:4>);
-recipes.remove(<forestry:planks.vanilla.fireproof.0:3>);
-recipes.remove(<forestry:planks.vanilla.fireproof.0:2>);
-recipes.remove(<forestry:planks.vanilla.fireproof.0:1>);
-recipes.remove(<forestry:planks.vanilla.fireproof.0>);
-recipes.remove(<forestry:planks.fireproof.1:12>);
-recipes.remove(<forestry:planks.fireproof.1:10>);
-recipes.remove(<forestry:planks.fireproof.1:9>);
-recipes.remove(<forestry:planks.fireproof.1:8>);
-recipes.remove(<forestry:planks.fireproof.1:7>);
-recipes.remove(<forestry:planks.fireproof.1:6>);
-recipes.remove(<forestry:planks.fireproof.1:5>);
-recipes.remove(<forestry:planks.fireproof.1:4>);
-recipes.remove(<forestry:planks.fireproof.1:3>);
-recipes.remove(<forestry:planks.fireproof.1:2>);
-recipes.remove(<forestry:planks.fireproof.1:1>);
-recipes.remove(<forestry:planks.fireproof.1>);
-recipes.remove(<forestry:planks.fireproof.0:15>);
-recipes.remove(<forestry:planks.fireproof.0:14>);
-recipes.remove(<forestry:planks.fireproof.0:13>);
-recipes.remove(<forestry:planks.fireproof.0:12>);
-recipes.remove(<forestry:planks.fireproof.0:11>);
-recipes.remove(<forestry:planks.fireproof.0:10>);
-recipes.remove(<forestry:planks.fireproof.0:9>);
-recipes.remove(<forestry:planks.fireproof.0:8>);
-recipes.remove(<forestry:planks.fireproof.0:7>);
-recipes.remove(<forestry:planks.fireproof.0:6>);
-recipes.remove(<forestry:planks.fireproof.0:5>);
-recipes.remove(<forestry:planks.fireproof.0:4>);
-recipes.remove(<forestry:planks.fireproof.0:3>);
-recipes.remove(<forestry:planks.fireproof.0:2>);
-recipes.remove(<forestry:planks.fireproof.0:1>);
-recipes.remove(<forestry:planks.fireproof.0>);
-recipes.remove(<forestry:planks.1:12>);
-recipes.remove(<forestry:planks.1:11>);
-recipes.remove(<forestry:planks.1:10>);
-recipes.remove(<forestry:planks.1:9>);
-recipes.remove(<forestry:planks.1:8>);
-recipes.remove(<forestry:planks.1:7>);
-recipes.remove(<forestry:planks.1:6>);
-recipes.remove(<forestry:planks.1:5>);
-recipes.remove(<forestry:planks.1:4>);
-recipes.remove(<forestry:planks.1:3>);
-recipes.remove(<forestry:planks.1:2>);
-recipes.remove(<forestry:planks.1:1>);
-recipes.remove(<forestry:planks.1>);
-recipes.remove(<forestry:planks.0:15>);
-recipes.remove(<forestry:planks.0:14>);
-recipes.remove(<forestry:planks.0:13>);
-recipes.remove(<forestry:planks.0:12>);
-recipes.remove(<forestry:planks.0:11>);
-recipes.remove(<forestry:planks.0:10>);
-recipes.remove(<forestry:planks.0:9>);
-recipes.remove(<forestry:planks.0:8>);
-recipes.remove(<forestry:planks.0:7>);
-recipes.remove(<forestry:planks.0:6>);
-recipes.remove(<forestry:planks.0:5>);
-recipes.remove(<forestry:planks.0:4>);
-recipes.remove(<forestry:planks.0:3>);
-recipes.remove(<forestry:planks.0:2>);
-recipes.remove(<forestry:planks.0:1>);
-recipes.remove(<forestry:planks.0>);
-recipes.remove(<extrautils2:ironwood_planks>);
-recipes.remove(<extrautils2:ironwood_planks:1>);
-recipes.remove(<thaumcraft:plank_silverwood>);
-recipes.remove(<thaumcraft:plank_greatwood>);
-recipes.addShapeless(<minecraft:planks> * 2, [<minecraft:log>]);
-recipes.addShapeless(<minecraft:planks:1> * 2, [<minecraft:log:1>]);
-recipes.addShapeless(<minecraft:planks:2> * 2, [<minecraft:log:2>]);
-recipes.addShapeless(<minecraft:planks:3> * 2, [<minecraft:log:3>]);
-recipes.addShapeless(<minecraft:planks:5>* 2, [<minecraft:log2:1>]);
-recipes.addShapeless(<minecraft:planks:4> * 2, [<minecraft:log2>]);
-recipes.addShapeless(<bewitchment:cypress_planks> * 2, [<bewitchment:cypress_wood>]);
-recipes.addShapeless(<bewitchment:elder_planks> * 2, [<bewitchment:elder_wood>]);
-recipes.addShapeless(<bewitchment:dragons_blood_planks> * 2, [<bewitchment:dragons_blood_wood>]);
-recipes.addShapeless(<biomesoplenty:planks_0> * 2, [<biomesoplenty:log_0:4>]);
-recipes.addShapeless(<biomesoplenty:planks_0:1> * 2, [<biomesoplenty:log_0:5>]);
-recipes.addShapeless(<biomesoplenty:planks_0:2> * 2, [<biomesoplenty:log_0:6>]);
-recipes.addShapeless(<biomesoplenty:planks_0:3> * 2, [<biomesoplenty:log_0:7>]);
-recipes.addShapeless(<biomesoplenty:planks_0:4> * 2, [<biomesoplenty:log_1:4>]);
-recipes.addShapeless(<biomesoplenty:planks_0:5> * 2, [<biomesoplenty:log_1:5>]);
-recipes.addShapeless(<biomesoplenty:planks_0:14> * 2, [<biomesoplenty:log_3:6>]);
-recipes.addShapeless(<biomesoplenty:planks_0:12> * 2, [<biomesoplenty:log_3:4>]);
-recipes.addShapeless(<biomesoplenty:planks_0:11> * 2, [<biomesoplenty:log_2:7>]);
-recipes.addShapeless(<forestry:planks.1:4> * 2, [<biomesoplenty:log_2:6>]);
-recipes.addShapeless(<forestry:planks.0:12> * 2, [<biomesoplenty:log_2:5>]);
-recipes.addShapeless(<biomesoplenty:planks_0:8> * 2, [<biomesoplenty:log_2:4>]);
-recipes.addShapeless(<forestry:planks.1:2> * 2, [<biomesoplenty:log_1:7>]);
-recipes.addShapeless(<biomesoplenty:planks_0:6> * 2, [<biomesoplenty:log_1:6>]);
-recipes.addShapeless(<natura:overworld_planks:5> * 2, [<biomesoplenty:log_3:7>]);
-recipes.addShapeless(<forestry:planks.0:10> * 2, [<biomesoplenty:log_3:5>]);
-recipes.addShapeless(<twilightforest:mine_planks> * 2, [<twilightforest:magic_log:2>]);
-recipes.addShapeless(<twilightforest:sort_planks> * 2, [<twilightforest:magic_log:3>]);
-recipes.addShapeless(<twilightforest:twilight_oak_planks> * 2, [<twilightforest:twilight_log>]);
-recipes.addShapeless(<twilightforest:time_planks> * 2, [<twilightforest:magic_log>]);
-recipes.addShapeless(<twilightforest:canopy_planks> * 2, [<twilightforest:twilight_log:1>]);
-recipes.addShapeless(<twilightforest:trans_planks> * 2, [<twilightforest:magic_log:1>]);
-recipes.addShapeless(<twilightforest:mangrove_planks> * 2, [<twilightforest:twilight_log:2>]);
-recipes.addShapeless(<twilightforest:dark_planks> * 2, [<twilightforest:twilight_log:3>]);
-recipes.addShapeless(<forestry:planks.vanilla.fireproof.0:5> * 2, [<forestry:logs.vanilla.fireproof.1:1>]);
-recipes.addShapeless(<forestry:planks.vanilla.fireproof.0:4> * 2, [<forestry:logs.vanilla.fireproof.1>]);
-recipes.addShapeless(<forestry:planks.vanilla.fireproof.0:3> * 2, [<forestry:logs.vanilla.fireproof.0:3>]);
-recipes.addShapeless(<forestry:planks.vanilla.fireproof.0:2> * 2, [<forestry:logs.vanilla.fireproof.0:2>]);
-recipes.addShapeless(<forestry:planks.vanilla.fireproof.0:1> * 2, [<forestry:logs.vanilla.fireproof.0:1>]);
-recipes.addShapeless(<forestry:planks.vanilla.fireproof.0> * 2, [<forestry:logs.vanilla.fireproof.0>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:12> * 2, [<forestry:logs.fireproof.7>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:11> * 2, [<forestry:logs.fireproof.6:3>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:10> * 2, [<forestry:logs.fireproof.6:2>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:9> * 2, [<forestry:logs.fireproof.6:1>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:8> * 2, [<forestry:logs.fireproof.6>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:7> * 2, [<forestry:logs.fireproof.5:3>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:6> * 2, [<forestry:logs.fireproof.5:2>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:5> * 2, [<forestry:logs.fireproof.5:1>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:4> * 2, [<forestry:logs.fireproof.5>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:3> * 2, [<forestry:logs.fireproof.4:3>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:2> * 2, [<forestry:logs.fireproof.4:2>]);
-recipes.addShapeless(<forestry:planks.fireproof.1:1> * 2, [<forestry:logs.fireproof.4:1>]);
-recipes.addShapeless(<forestry:planks.fireproof.1> * 2, [<forestry:logs.fireproof.4>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:15> * 2, [<forestry:logs.fireproof.3:3>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:14> * 2, [<forestry:logs.fireproof.3:2>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:13> * 2, [<forestry:logs.fireproof.3:1>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:12> * 2, [<forestry:logs.fireproof.3>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:11> * 2, [<forestry:logs.fireproof.2:3>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:10> * 2, [<forestry:logs.fireproof.2:2>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:9> * 2, [<forestry:logs.fireproof.2:1>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:8> * 2, [<forestry:logs.fireproof.2>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:7> * 2, [<forestry:logs.fireproof.1:3>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:6> * 2, [<forestry:logs.fireproof.1:2>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:5> * 2, [<forestry:logs.fireproof.1:1>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:4> * 2, [<forestry:logs.fireproof.1>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:3> * 2, [<forestry:logs.fireproof.0:3>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:2> * 2, [<forestry:logs.fireproof.0:2>]);
-recipes.addShapeless(<forestry:planks.fireproof.0:1> * 2, [<forestry:logs.fireproof.0:1>]);
-recipes.addShapeless(<forestry:planks.fireproof.0> * 2, [<forestry:logs.fireproof.0>]);
-recipes.addShapeless(<forestry:planks.1:11> * 2, [<forestry:logs.6:3>]);
-recipes.addShapeless(<forestry:planks.1:12> * 2, [<forestry:logs.7>]);
-recipes.addShapeless(<forestry:planks.1:10> * 2, [<forestry:logs.6:2>]);
-recipes.addShapeless(<forestry:planks.1:9> * 2, [<forestry:logs.6:1>]);
-recipes.addShapeless(<forestry:planks.1:8> * 2, [<forestry:logs.6>]);
-recipes.addShapeless(<forestry:planks.1:7> * 2, [<forestry:logs.5:3>]);
-recipes.addShapeless(<forestry:planks.1:6> * 2, [<forestry:logs.5:2>]);
-recipes.addShapeless(<forestry:planks.1:5> * 2, [<forestry:logs.5:1>]);
-recipes.addShapeless(<forestry:planks.1:4> * 2, [<forestry:logs.5>]);
-recipes.addShapeless(<forestry:planks.1:3> * 2, [<forestry:logs.4:3>]);
-recipes.addShapeless(<forestry:planks.1:2> * 2, [<forestry:logs.4:2>]);
-recipes.addShapeless(<forestry:planks.1:1> * 2, [<forestry:logs.4:1>]);
-recipes.addShapeless(<forestry:planks.1> * 2, [<forestry:logs.4>]);
-recipes.addShapeless(<forestry:planks.0:15> * 2, [<forestry:logs.3:3>]);
-recipes.addShapeless(<forestry:planks.0:14> * 2, [<forestry:logs.3:2>]);
-recipes.addShapeless(<forestry:planks.0:13> * 2, [<forestry:logs.3:1>]);
-recipes.addShapeless(<forestry:planks.0:12> * 2, [<forestry:logs.3>]);
-recipes.addShapeless(<forestry:planks.0:11> * 2, [<forestry:logs.2:3>]);
-recipes.addShapeless(<forestry:planks.0:10> * 2, [<forestry:logs.2:2>]);
-recipes.addShapeless(<forestry:planks.0:9> * 2, [<forestry:logs.2:1>]);
-recipes.addShapeless(<forestry:planks.0:8> * 2, [<forestry:logs.2>]);
-recipes.addShapeless(<forestry:planks.0:7> * 2, [<forestry:logs.1:3>]);
-recipes.addShapeless(<forestry:planks.0:6> * 2, [<forestry:logs.1:2>]);
-recipes.addShapeless(<forestry:planks.0:5> * 2, [<forestry:logs.1:1>]);
-recipes.addShapeless(<forestry:planks.0:4> * 2, [<forestry:logs.1>]);
-recipes.addShapeless(<forestry:planks.0:3> * 2, [<forestry:logs.0:3>]);
-recipes.addShapeless(<forestry:planks.0:2> * 2, [<forestry:logs.0:2>]);
-recipes.addShapeless(<forestry:planks.0:1> * 2, [<forestry:logs.0:1>]);
-recipes.addShapeless(<forestry:planks.0> * 2, [<forestry:logs.0>]);
-recipes.addShapeless(<extrautils2:ironwood_planks> * 2, [<extrautils2:ironwood_log>]);
-recipes.addShapeless(<extrautils2:ironwood_planks:1> * 2, [<extrautils2:ironwood_log:1>]);
-recipes.addShapeless(<thaumcraft:plank_greatwood> * 2, [<thaumcraft:log_greatwood>]);
-recipes.addShapeless(<thaumcraft:plank_silverwood> * 2, [<thaumcraft:log_silverwood>]);
-recipes.addShapeless(<natura:overworld_planks:5> * 2, [<extratrees:logs.8>]);
-recipes.addShapeless(<natura:overworld_planks:5> * 2, [<natura:overworld_logs2:1>]);
-recipes.addShapeless(<natura:overworld_planks:5> * 2, [<extratrees:logs.9>]);
-recipes.addShapeless(<extratrees:logs.fireproof.9> * 2, [<extratrees:logs.fireproof.9>]);
+#Recipe Remove for variant things
+    var WoodArray = [
+        # Log, Plank
+        [<minecraft:log>, <minecraft:planks>],
+        [<minecraft:log:1>, <minecraft:planks:1>],
+        [<minecraft:log:2>,<minecraft:planks:2>],
+        [<minecraft:log:3>,<minecraft:planks:3>],
+        [<minecraft:log2:1>,<minecraft:planks:5>],
+        [<minecraft:log2>,<minecraft:planks:4>],
 
+        [<extratrees:logs.0>, <extratrees:planks.0>],
+        [<extratrees:logs.0:1>, <extratrees:planks.0:1>],
+        [<extratrees:logs.0:2>, <extratrees:planks.0:2>],
+        [<extratrees:logs.0:3>, <extratrees:planks.0:3>],
+        [<extratrees:logs.1>, <extratrees:planks.0:4>],
+        [<extratrees:logs.1:1>, <extratrees:planks.0:5>],
+        [<extratrees:logs.1:2>, <extratrees:planks.0:6>],
+        [<extratrees:logs.1:3>, <extratrees:planks.0:7>],
+        [<extratrees:logs.2>, <extratrees:planks.0:8>],
+        [<extratrees:logs.2:1>, <extratrees:planks.0:9>],
+        [<extratrees:logs.2:2>, <extratrees:planks.0:10>],
+        [<extratrees:logs.2:3>, <extratrees:planks.0:11>],
+        [<extratrees:logs.3>, <extratrees:planks.0:12>],
+        [<extratrees:logs.3:1>, <extratrees:planks.0:13>],
+        [<extratrees:logs.3:2>, <extratrees:planks.0:14>],
+        [<extratrees:logs.3:3>, <extratrees:planks.0:15>],
+        [<extratrees:logs.4>, <extratrees:planks.1>],
+        [<extratrees:logs.4:1>, <extratrees:planks.1:1>],
+        [<extratrees:logs.4:2>, <extratrees:planks.1:2>],
+        [<extratrees:logs.4:3>, <extratrees:planks.1:3>],
+        [<extratrees:logs.5>, <extratrees:planks.1:4>],
+        [<extratrees:logs.5:1>, <extratrees:planks.1:5>],
+        [<extratrees:logs.5:2>, <extratrees:planks.1:6>],
+        [<extratrees:logs.5:3>, <extratrees:planks.1:7>],
+        [<extratrees:logs.6>, <extratrees:planks.1:8>],
+        [<extratrees:logs.6:1>, <extratrees:planks.1:9>],
+        [<extratrees:logs.6:2>, <extratrees:planks.1:10>],
+        [<extratrees:logs.6:3>, <extratrees:planks.1:11>],
+        [<extratrees:logs.7>, <extratrees:planks.1:12>],
+        [<extratrees:logs.7:1>, <extratrees:planks.1:13>],
+        [<extratrees:logs.7:2>, <extratrees:planks.1:14>],
+        [<extratrees:logs.7:3>, <extratrees:planks.1:15>],
+        [<extratrees:logs.8:1>, <extratrees:planks.2>],
+        [<extratrees:logs.8:2>, <extratrees:planks.2:1>],
+        [<extratrees:logs.8:3>, <extratrees:planks.2:2>],
+        [<extratrees:logs.9:1>, <extratrees:planks.2:3>],
+        [<extratrees:logs.fireproof.0>, <extratrees:planks.fireproof.0>],
+        [<extratrees:logs.fireproof.0:1>, <extratrees:planks.fireproof.0:1>],
+        [<extratrees:logs.fireproof.0:2>, <extratrees:planks.fireproof.0:2>],
+        [<extratrees:logs.fireproof.0:3>, <extratrees:planks.fireproof.0:3>],
+        [<extratrees:logs.fireproof.1>, <extratrees:planks.fireproof.0:4>],
+        [<extratrees:logs.fireproof.1:1>, <extratrees:planks.fireproof.0:5>],
+        [<extratrees:logs.fireproof.1:2>, <extratrees:planks.fireproof.0:6>],
+        [<extratrees:logs.fireproof.1:3>, <extratrees:planks.fireproof.0:7>],
+        [<extratrees:logs.fireproof.2>, <extratrees:planks.fireproof.0:8>],
+        [<extratrees:logs.fireproof.2:1>, <extratrees:planks.fireproof.0:9>],
+        [<extratrees:logs.fireproof.2:2>, <extratrees:planks.fireproof.0:10>],
+        [<extratrees:logs.fireproof.2:3>, <extratrees:planks.fireproof.0:11>],
+        [<extratrees:logs.fireproof.3>, <extratrees:planks.fireproof.0:12>],
+        [<extratrees:logs.fireproof.3:1>, <extratrees:planks.fireproof.0:13>],
+        [<extratrees:logs.fireproof.3:2>, <extratrees:planks.fireproof.0:14>],
+        [<extratrees:logs.fireproof.3:3>, <extratrees:planks.fireproof.0:15>],
+        [<extratrees:logs.fireproof.4>, <extratrees:planks.fireproof.1>],
+        [<extratrees:logs.fireproof.4:1>, <extratrees:planks.fireproof.1:1>],
+        [<extratrees:logs.fireproof.4:2>, <extratrees:planks.fireproof.1:2>],
+        [<extratrees:logs.fireproof.4:3>, <extratrees:planks.fireproof.1:3>],
+        [<extratrees:logs.fireproof.5>, <extratrees:planks.fireproof.1:4>],
+        [<extratrees:logs.fireproof.5:1>, <extratrees:planks.fireproof.1:5>],
+        [<extratrees:logs.fireproof.5:2>, <extratrees:planks.fireproof.1:6>],
+        [<extratrees:logs.fireproof.5:3>, <extratrees:planks.fireproof.1:7>],
+        [<extratrees:logs.fireproof.6>, <extratrees:planks.fireproof.1:8>],
+        [<extratrees:logs.fireproof.6:1>, <extratrees:planks.fireproof.1:9>],
+        [<extratrees:logs.fireproof.6:2>, <extratrees:planks.fireproof.1:10>],
+        [<extratrees:logs.fireproof.6:3>, <extratrees:planks.fireproof.1:11>],
+        [<extratrees:logs.fireproof.7>, <extratrees:planks.fireproof.1:12>],
+        [<extratrees:logs.fireproof.7:1>, <extratrees:planks.fireproof.1:13>],
+        [<extratrees:logs.fireproof.7:2>, <extratrees:planks.fireproof.1:14>],
+        [<extratrees:logs.fireproof.7:3>, <extratrees:planks.fireproof.1:15>],
+        [<extratrees:logs.fireproof.8:1>, <extratrees:planks.fireproof.2>],
+        [<extratrees:logs.fireproof.8:2>, <extratrees:planks.fireproof.2:1>],
+        [<extratrees:logs.fireproof.8:3>, <extratrees:planks.fireproof.2:2>],
+        [<extratrees:logs.fireproof.9:1>, <extratrees:planks.fireproof.2:3>],
+        [<extratrees:logs.fireproof.9:3>, <forestry:planks.vanilla.fireproof.0:3>],
+        [<extratrees:logs.fireproof.9:2>, <forestry:planks.fireproof.0:15>],
 
+        [<biomesoplenty:log_0:4>, <biomesoplenty:planks_0:0>],
+        [<biomesoplenty:log_0:5>, <biomesoplenty:planks_0:1>],
+        [<biomesoplenty:log_0:6>, <biomesoplenty:planks_0:2>],
+        [<biomesoplenty:log_0:7>, <biomesoplenty:planks_0:3>],
+        [<biomesoplenty:log_1:4>, <biomesoplenty:planks_0:4>],
+        [<biomesoplenty:log_1:5>, <biomesoplenty:planks_0:5>],
+        [<biomesoplenty:log_1:6>, <biomesoplenty:planks_0:6>],
+        [<biomesoplenty:log_1:7>, <biomesoplenty:planks_0:7>],
+        [<biomesoplenty:log_2:4>, <biomesoplenty:planks_0:8>],
+        [<biomesoplenty:log_2:5>, <biomesoplenty:planks_0:9>],
+        [<biomesoplenty:log_2:6>, <biomesoplenty:planks_0:10>],
+        [<biomesoplenty:log_2:7>, <biomesoplenty:planks_0:11>],
+        [<biomesoplenty:log_3:4>, <biomesoplenty:planks_0:12>],
+        [<biomesoplenty:log_3:5>, <biomesoplenty:planks_0:13>],
+        [<biomesoplenty:log_3:6>, <biomesoplenty:planks_0:14>],
+        [<biomesoplenty:log_3:7>, <biomesoplenty:planks_0:15>],
+        [<biomesoplenty:log_2:6> ,<forestry:planks.1:4>],
+        [<biomesoplenty:log_2:5>, <forestry:planks.0:12>],
+        [<biomesoplenty:log_1:7>, <forestry:planks.1:2>],
+        [<biomesoplenty:log_3:5>, <forestry:planks.0:10>],
 
+        [<bewitchment:cypress_wood>, <bewitchment:cypress_planks>],
+        [<bewitchment:elder_wood>, <bewitchment:elder_planks>],
+        [<bewitchment:dragons_blood_wood>, <bewitchment:dragons_blood_planks>],
+        [<bewitchment:juniper_wood>, <bewitchment:juniper_planks>],
 
+        [<forestry:logs.vanilla.fireproof.1:1>,<forestry:planks.vanilla.fireproof.0:5>],
+        [<forestry:logs.vanilla.fireproof.1>,<forestry:planks.vanilla.fireproof.0:4>],
+        [<forestry:logs.vanilla.fireproof.0:3>, <forestry:planks.vanilla.fireproof.0:3>],
+        [<forestry:logs.vanilla.fireproof.0:2>, <forestry:planks.vanilla.fireproof.0:2>],
+        [<forestry:logs.vanilla.fireproof.0:1>, <forestry:planks.vanilla.fireproof.0:1>],
+        [<forestry:logs.vanilla.fireproof.0>, <forestry:planks.vanilla.fireproof.0>],
+        [<forestry:logs.fireproof.7>, <forestry:planks.fireproof.1:12>],
+        [<forestry:logs.fireproof.6:3>, <forestry:planks.fireproof.1:11>],
+        [<forestry:logs.fireproof.6:2>, <forestry:planks.fireproof.1:10>],
+        [<forestry:logs.fireproof.6:1>, <forestry:planks.fireproof.1:9>],
+        [<forestry:logs.fireproof.6>, <forestry:planks.fireproof.1:8>],
+        [<forestry:logs.fireproof.5:3>, <forestry:planks.fireproof.1:7>],
+        [<forestry:logs.fireproof.5:2>, <forestry:planks.fireproof.1:6>],
+        [<forestry:logs.fireproof.5:1>, <forestry:planks.fireproof.1:5>],
+        [<forestry:logs.fireproof.5>, <forestry:planks.fireproof.1:4>],
+        [<forestry:logs.fireproof.4:3>, <forestry:planks.fireproof.1:3>],
+        [<forestry:logs.fireproof.4:2>, <forestry:planks.fireproof.1:2>],
+        [<forestry:logs.fireproof.4:1>, <forestry:planks.fireproof.1:1>],
+        [<forestry:logs.fireproof.4>, <forestry:planks.fireproof.1>],
+        [<forestry:logs.fireproof.3:3>, <forestry:planks.fireproof.0:15>],
+        [<forestry:logs.fireproof.3:2>, <forestry:planks.fireproof.0:14>],
+        [<forestry:logs.fireproof.3:1>, <forestry:planks.fireproof.0:13>],
+        [<forestry:logs.fireproof.3>, <forestry:planks.fireproof.0:12>],
+        [<forestry:logs.fireproof.2:3>, <forestry:planks.fireproof.0:11>],
+        [<forestry:logs.fireproof.2:2>, <forestry:planks.fireproof.0:10>],
+        [<forestry:logs.fireproof.2:1>, <forestry:planks.fireproof.0:9>],
+        [<forestry:logs.fireproof.2>, <forestry:planks.fireproof.0:8>],
+        [<forestry:logs.fireproof.1:3>, <forestry:planks.fireproof.0:7>],
+        [<forestry:logs.fireproof.1:2>, <forestry:planks.fireproof.0:6>],
+        [<forestry:logs.fireproof.1:1>, <forestry:planks.fireproof.0:5>],
+        [<forestry:logs.fireproof.1>, <forestry:planks.fireproof.0:4>],
+        [<forestry:logs.fireproof.0:3>, <forestry:planks.fireproof.0:3>],
+        [<forestry:logs.fireproof.0:2>, <forestry:planks.fireproof.0:2>],
+        [<forestry:logs.fireproof.0:1>, <forestry:planks.fireproof.0:1>],
+        [<forestry:logs.fireproof.0>, <forestry:planks.fireproof.0>],
+        [<forestry:logs.6:3>, <forestry:planks.1:11>],
+        [<forestry:logs.7>, <forestry:planks.1:12>],
+        [<forestry:logs.6:2>, <forestry:planks.1:10>],
+        [<forestry:logs.6:1>, <forestry:planks.1:9>],
+        [<forestry:logs.6>, <forestry:planks.1:8>],
+        [<forestry:logs.5:3>, <forestry:planks.1:7>],
+        [<forestry:logs.5:2>, <forestry:planks.1:6>],
+        [<forestry:logs.5:1>, <forestry:planks.1:5>],
+        [<forestry:logs.5>, <forestry:planks.1:4>],
+        [<forestry:logs.4:3>, <forestry:planks.1:3>],
+        [<forestry:logs.4:2>, <forestry:planks.1:2>],
+        [<forestry:logs.4:1>, <forestry:planks.1:1>],
+        [<forestry:logs.4>, <forestry:planks.1>],
+        [<forestry:logs.3:3>, <forestry:planks.0:15>],
+        [<forestry:logs.3:2>, <forestry:planks.0:14>],
+        [<forestry:logs.3:1>, <forestry:planks.0:13>],
+        [<forestry:logs.3>, <forestry:planks.0:12>],
+        [<forestry:logs.2:3>, <forestry:planks.0:11>],
+        [<forestry:logs.2:2>, <forestry:planks.0:10>],
+        [<forestry:logs.2:1>, <forestry:planks.0:9>],
+        [<forestry:logs.2>, <forestry:planks.0:8>],
+        [<forestry:logs.1:3>, <forestry:planks.0:7>],
+        [<forestry:logs.1:2>, <forestry:planks.0:6>],
+        [<forestry:logs.1:1>, <forestry:planks.0:5>],
+        [<forestry:logs.1>, <forestry:planks.0:4>],
+        [<forestry:logs.0:3>, <forestry:planks.0:3>],
+        [<forestry:logs.0:2>, <forestry:planks.0:2>],
+        [<forestry:logs.0:1>, <forestry:planks.0:1>],
+        [<forestry:logs.0>, <forestry:planks.0>],
+
+        [<extrautils2:ironwood_log>, <extrautils2:ironwood_planks>],
+        [<extrautils2:ironwood_log:1>, <extrautils2:ironwood_planks:1>],
+
+        [<thaumcraft:log_greatwood>, <thaumcraft:plank_greatwood>],
+        [<thaumcraft:log_silverwood>, <thaumcraft:plank_silverwood>],
+
+        [<natura:nether_logs2:15>, <natura:nether_planks:1>],
+        [<natura:nether_logs2>, <natura:nether_planks:1>],
+        [<natura:overworld_logs:1>, <natura:overworld_planks:1>],
+        [<natura:overworld_logs>, <natura:overworld_planks>],
+        [<natura:overworld_logs2:3>, <natura:overworld_planks:7>],
+        [<natura:overworld_logs2:2>, <natura:overworld_planks:6>],
+        [<natura:overworld_logs:2>, <natura:overworld_planks:2>],
+        [<natura:overworld_logs:3>, <natura:overworld_planks:3>],
+        [<natura:nether_logs:2>, <natura:nether_planks:3>],
+        [<natura:overworld_logs2>, <natura:overworld_planks:4>],
+        [<natura:nether_logs>, <natura:nether_planks>],
+        [<natura:nether_logs:1>, <natura:nether_planks:2>],
+        [<natura:overworld_logs2:1>, <natura:overworld_planks:5>],
+        [<natura:redwood_logs:1>, <natura:overworld_planks:8>],
+
+        [<twilightforest:magic_log:2>, <twilightforest:mine_planks>],
+        [<twilightforest:magic_log:3>, <twilightforest:sort_planks>],
+        [<twilightforest:twilight_log>, <twilightforest:twilight_oak_planks>],
+        [<twilightforest:magic_log>, <twilightforest:time_planks>],
+        [<twilightforest:twilight_log:1>, <twilightforest:canopy_planks>],
+        [<twilightforest:magic_log:1>, <twilightforest:trans_planks>],
+        [<twilightforest:twilight_log:2>, <twilightforest:mangrove_planks>],
+        [<twilightforest:twilight_log:3>, <twilightforest:dark_planks>],
+
+ ] as crafttweaker.item.IItemStack[][];
+
+for i, log_pair in WoodArray {
+      var log = log_pair[0];
+      var plank = log_pair[1];
+
+    #Planks
+    recipes.addShapeless(plank * 2, [log]);
+    recipes.remove(plank);
+    recipes.removeShapeless(plank);
+}
+
+var ArmorRemove = [
+    <minecraft:diamond_boots>,
+    <minecraft:diamond_leggings>,
+    <minecraft:diamond_chestplate>,
+    <minecraft:diamond_helmet>,
+    <minecraft:golden_boots>,
+    <minecraft:golden_leggings>,
+    <minecraft:golden_chestplate>,
+    <minecraft:golden_helmet>,
+    <minecraft:iron_boots>,
+    <minecraft:iron_leggings>,
+    <minecraft:iron_helmet>,
+    <minecraft:iron_chestplate>,
+    <minecraft:leather_helmet>,
+    <minecraft:leather_leggings>,
+    <minecraft:leather_boots>,
+    <minecraft:leather_chestplate>
+
+] as IItemStack[];
+
+var CraftingOnlyTools = [
+
+<minecraft:golden_axe>,
+<minecraft:golden_shovel>,
+<minecraft:diamond_hoe>,
+<minecraft:diamond_sword>,
+<minecraft:diamond_shovel>,
+<minecraft:diamond_axe>,
+<minecraft:diamond_pickaxe>,
+<minecraft:golden_pickaxe>,
+<minecraft:iron_shovel>,
+<minecraft:iron_axe>,
+<minecraft:iron_pickaxe>,
+<minecraft:iron_sword>,
+<minecraft:golden_sword>,
+<minecraft:golden_hoe>,
+<railcraft:tool_sword_steel>,
+<railcraft:tool_pickaxe_steel>,
+<railcraft:tool_axe_steel>,
+<railcraft:tool_shovel_steel>,
+<railcraft:tool_hoe_steel>,
+<ic2:bronze_sword>,
+<ic2:bronze_pickaxe>,
+<ic2:bronze_axe>,
+<ic2:bronze_shovel>,
+<ic2:bronze_hoe>,
+<thermalfoundation:tool.sword_invar>,
+<thermalfoundation:tool.pickaxe_invar>
+
+] as IItemStack[];
+
+var RecipeIDsRemove as string[] = [
+
+    #Stick recipes that were added by several mods
+	    "twilightforest:stick",
+        "stevescarts:component/twig_sticks",
+        "enderio:tweak_stick_from_wood",
+        "extrautils2:shortcut_stick",
+];
+
+    for IDRemove in RecipeIDsRemove {
+	    recipes.removeByRecipeName(IDRemove);
+}
+
+    for items in ArmorRemove {
+		recipes.remove(items);
+}
+
+    for ItemTooltip in CraftingOnlyTools {
+		ItemTooltip.addTooltip(format.red("Used For Crafting Only!"));
+}
+
+#Stick
+recipes.remove(<minecraft:stick>);
+
+# --Stick 2x Adding
+recipes.addShapedMirrored(<minecraft:stick> * 2, 
+[
+    [null, <ore:plankWood>, null], 
+    [null, <ore:plankWood>, null], 
+    [null, null, null]
+]);
+
+# --Stick 8x Adding
+recipes.addShaped(<minecraft:stick> * 8, 
+[
+    [null, <ore:logWood>, null], 
+    [null, <ore:logWood>, null], 
+    [null, null, null]
+]);
 
 #Chest
 recipes.removeShaped(<minecraft:chest> *4, [[<ore:logWood>, <ore:logWood>, <ore:logWood>], [<ore:logWood>, null, <ore:logWood>], [<ore:logWood>, <ore:logWood>, <ore:logWood>]]);
@@ -225,17 +322,8 @@ recipes.addShaped(<minecraft:chest> *2, [[<ore:logWood>, <ore:logWood>, <ore:log
 recipes.remove(<minecraft:furnace>);
 recipes.addShaped(<minecraft:furnace>, [[<ore:compressed1xCobblestone>, <ore:compressed1xCobblestone>, <ore:compressed1xCobblestone>], [<ore:compressed1xCobblestone>, null, <ore:compressed1xCobblestone>], [<ore:compressed1xCobblestone>, <ore:compressed1xCobblestone>, <extrautils2:compressedcobblestone>]]);
 
-#Remove Lava Generators
-mods.jei.JEI.removeAndHide(<extrautils2:machine>.withTag({Type: "extrautils2:generator_lava"}));
-mods.jei.JEI.removeAndHide(<enderio:block_lava_generator>);
-mods.jei.JEI.removeAndHide(<extrautils2:passivegenerator:2>);
-mods.jei.JEI.removeAndHide(<ic2:te:4>);
-mods.jei.JEI.removeAndHide(<immersiveengineering:metal_device1:3>);
-mods.jei.JEI.removeAndHide(<thermalexpansion:dynamo:1>);
-
 #Flint and Steel
 recipes.remove(<minecraft:flint_and_steel>);
-#recipes.addShaped(<minecraft:flint_and_steel>, [[<ore:itemFlint>, <ore:ingotSteel>]]);
 recipes.addShaped(<minecraft:flint_and_steel>, [[<ore:ingotSteel>, null, null], [null, <ore:itemFlint>, null], [null, null, null]]);
 
 #Bucket
@@ -245,24 +333,6 @@ recipes.addShaped(<minecraft:bucket>, [[<ore:plateIron>, null, <ore:plateIron>],
 #Cauldron
 recipes.remove(<minecraft:cauldron>);
 recipes.addShaped(<minecraft:cauldron>, [[<ore:plateIron>, null, <ore:plateIron>], [<ore:plateIron>, null, <ore:plateIron>], [<ore:plateIron>, <ore:plateIron>, <ore:plateIron>]]);
-
-#Armor
-recipes.remove(<minecraft:diamond_boots>);
-recipes.remove(<minecraft:diamond_leggings>);
-recipes.remove(<minecraft:diamond_chestplate>);
-recipes.remove(<minecraft:diamond_helmet>);
-recipes.remove(<minecraft:golden_boots>);
-recipes.remove(<minecraft:golden_leggings>);
-recipes.remove(<minecraft:golden_chestplate>);
-recipes.remove(<minecraft:golden_helmet>);
-recipes.remove(<minecraft:iron_boots>);
-recipes.remove(<minecraft:iron_leggings>);
-recipes.remove(<minecraft:iron_helmet>);
-recipes.remove(<minecraft:iron_chestplate>);
-recipes.remove(<minecraft:leather_helmet>);
-recipes.remove(<minecraft:leather_leggings>);
-recipes.remove(<minecraft:leather_boots>);
-recipes.remove(<minecraft:leather_chestplate>);
 
 recipes.addShaped(<minecraft:diamond_boots>, [[<minecraft:diamond>, <minecraft:golden_boots>, <minecraft:diamond>], [<minecraft:diamond>, null, <minecraft:diamond>]]);
 recipes.addShaped(<minecraft:diamond_leggings>, [[<minecraft:diamond>, <minecraft:diamond>, <minecraft:diamond>], [<minecraft:diamond>, <minecraft:golden_leggings>, <minecraft:diamond>], [<minecraft:diamond>, null, <minecraft:diamond>]]);
@@ -316,33 +386,5 @@ recipes.addShaped(<minecraft:iron_helmet>, [[<ore:ingotIron>, <ore:ingotIron>, <
 <projectred-exploration:peridot_chestplate>.maxDamage = 16;
 <projectred-exploration:peridot_leggings>.maxDamage = 16;
 <projectred-exploration:peridot_boots>.maxDamage = 16;
-
-#tooltips
-<minecraft:golden_axe>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:golden_shovel>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:diamond_hoe>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:diamond_sword>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:diamond_shovel>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:diamond_axe>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:diamond_pickaxe>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:golden_pickaxe>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:iron_shovel>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:iron_axe>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:iron_pickaxe>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:iron_sword>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:golden_sword>.addTooltip(format.red("Used For Crafting Only!"));
-<minecraft:golden_hoe>.addTooltip(format.red("Used For Crafting Only!"));
-<railcraft:tool_sword_steel>.addTooltip(format.red("Used For Crafting Only!"));
-<railcraft:tool_pickaxe_steel>.addTooltip(format.red("Used For Crafting Only!"));
-<railcraft:tool_axe_steel>.addTooltip(format.red("Used For Crafting Only!"));
-<railcraft:tool_shovel_steel>.addTooltip(format.red("Used For Crafting Only!"));
-<railcraft:tool_hoe_steel>.addTooltip(format.red("Used For Crafting Only!"));
-<ic2:bronze_sword>.addTooltip(format.red("Used For Crafting Only!"));
-<ic2:bronze_pickaxe>.addTooltip(format.red("Used For Crafting Only!"));
-<ic2:bronze_axe>.addTooltip(format.red("Used For Crafting Only!"));
-<ic2:bronze_shovel>.addTooltip(format.red("Used For Crafting Only!"));
-<ic2:bronze_hoe>.addTooltip(format.red("Used For Crafting Only!"));
-<thermalfoundation:tool.sword_invar>.addTooltip(format.red("Used For Crafting Only!"));
-<thermalfoundation:tool.pickaxe_invar>.addTooltip(format.red("Used For Crafting Only!"));
 
 print("Initialized 'MinecraftGettingStarted.zs'");

--- a/scripts/expert/RemoveAndHide.zs
+++ b/scripts/expert/RemoveAndHide.zs
@@ -8,59 +8,79 @@ import mods.jei.JEI.removeAndHide as rh;
 
 print("Initializing 'RemoveAndHide.zs'...");
 
-# Remove and Hide Items
-var recipesToRemove = [
-<appliedenergistics2:nether_quartz_wrench>,
-<extracells:vibrantchamberfluid>,
-<computercraft:turtle>,
-<appliedenergistics2:vibration_chamber>,
-<immersiveengineering:sword_steel>,
-<immersiveengineering:shovel_steel>,
-<immersiveengineering:axe_steel>,
-<immersiveengineering:pickaxe_steel>,
-<railcraft:gear:1>,
-<railcraft:gear:2>,
-<railcraft:gear:4>,
-<railcraft:gear:5>,
-<ic2:bronze_boots>,
-<ic2:bronze_chestplate>,
-<ic2:bronze_helmet>,
-<ic2:bronze_leggings>,
-<advanced_solar_panels:double_stone_slab>,
-<extrautils2:unstableingots>,
-<netherendingores:ore_end_modded_1:*>,
-<netherendingores:ore_nether_modded_1:12>,
-<netherendingores:ore_nether_modded_1:11>,
-<netherendingores:ore_nether_modded_1:14>,
-<netherendingores:ore_nether_modded_1:15>,
-<netherendingores:ore_nether_modded_2>,
-<netherendingores:ore_nether_modded_1:2>,
-<netherendingores:ore_other_1:*>,
-<netherendingores:ore_end_modded_2>,
-<netherendingores:ore_end_vanilla:*>,
-<twilightforest:uncrafting_table>,
-<randomthings:blockbreaker>,
-<randomthings:spectrecoil_normal>,
-<randomthings:spectrecoil_redstone>,
-<randomthings:spectrecoil_ender>,
-<randomthings:spectrecoil_number>,
-<randomthings:diviningrod:*>,
-<randomthings:spectrecoil_genesis>,
-<tconstruct:cast_custom:3>,
-<industrialforegoing:black_hole_controller>,
-<ic2:te:102>,
-<ic2:te:101>,
-<ic2:te:100>,
-<simplyjetpacks:itemjetpack:1>,
-<simplyjetpacks:itemjetpack:2>,
-<simplyjetpacks:itemjetpack:3>,
-<simplyjetpacks:itemjetpack:4>,
-<simplyjetpacks:itemjetpack:6>,
-<simplyjetpacks:itemjetpack:5>
-	] as IItemStack[];
+// The ids could change at any time, so I'll give them names
+// to at least know what they mean in the future.
+var fluxInfusedChestplateAssembly = <simplyjetpacks:metaitemmods:25>;
+var fluxedArmorPlating = <simplyjetpacks:metaitemmods:26>;
+var EU2LavaGen  = <extrautils2:machine>.withTag({Type: "extrautils2:generator_lava"});
 
-	for items in recipesToRemove {
-		rh(items);
-	}
+// Remove and Hide Items
+var recipesToRemove = [
+	<appliedenergistics2:nether_quartz_wrench>,
+	<extracells:vibrantchamberfluid>,
+	<computercraft:turtle>,
+	<appliedenergistics2:vibration_chamber>,
+	<immersiveengineering:sword_steel>,
+	<immersiveengineering:shovel_steel>,
+	<immersiveengineering:axe_steel>,
+	<immersiveengineering:pickaxe_steel>,
+	<railcraft:gear:1>,
+	<railcraft:gear:2>,
+	<railcraft:gear:4>,
+	<railcraft:gear:5>,
+	<ic2:bronze_boots>,
+	<ic2:bronze_chestplate>,
+	<ic2:bronze_helmet>,
+	<ic2:bronze_leggings>,
+	<advanced_solar_panels:double_stone_slab>,
+	<extrautils2:unstableingots>,
+	<netherendingores:ore_end_modded_1:*>,
+	<netherendingores:ore_nether_modded_1:12>,
+	<netherendingores:ore_nether_modded_1:11>,
+	<netherendingores:ore_nether_modded_1:14>,
+	<netherendingores:ore_nether_modded_1:15>,
+	<netherendingores:ore_nether_modded_2>,
+	<netherendingores:ore_nether_modded_1:2>,
+	<netherendingores:ore_other_1:*>,
+	<netherendingores:ore_end_modded_2>,
+	<netherendingores:ore_end_vanilla:*>,
+	<twilightforest:uncrafting_table>,
+	<randomthings:blockbreaker>,
+	<randomthings:spectrecoil_normal>,
+	<randomthings:spectrecoil_redstone>,
+	<randomthings:spectrecoil_ender>,
+	<randomthings:spectrecoil_number>,
+	<randomthings:diviningrod:*>,
+	<randomthings:spectrecoil_genesis>,
+	<tconstruct:cast_custom:3>,
+	<industrialforegoing:black_hole_controller>,
+	<ic2:te:102>,
+	<ic2:te:101>,
+	<ic2:te:100>,
+	<simplyjetpacks:itemjetpack:1>,
+	<simplyjetpacks:itemjetpack:2>,
+	<simplyjetpacks:itemjetpack:3>,
+	<simplyjetpacks:itemjetpack:4>,
+	<simplyjetpacks:itemjetpack:6>,
+	<simplyjetpacks:itemjetpack:5>,
+	fluxedArmorPlating,
+	fluxInfusedChestplateAssembly,
+<extrautils2:machine>.withTag({Type: "extrautils2:generator_lava"}),
+<enderio:block_lava_generator>,
+<extrautils2:passivegenerator:2>,
+<ic2:te:4>,
+<immersiveengineering:metal_device1:3>,
+<thermalexpansion:dynamo:1>,
+EU2LavaGen,
+<enderio:block_lava_generator>,
+<extrautils2:passivegenerator:2>,
+<ic2:te:4>,
+<immersiveengineering:metal_device1:3>,
+<thermalexpansion:dynamo:1>
+] as IItemStack[];
+
+for items in recipesToRemove {
+	rh(items);
+}
 
 print("Initialized 'RemoveAndHide.zs'");


### PR DESCRIPTION
**General:**
 - All stick recipes has now been removed and replaced with the 1.7.10 recipes ( 2 Planks = 2 Sticks - 2 Logs = 8 Sticks)
 - Switched Lava Generator RemoveAndHide from **MinecraftGettingStarted.zs** to **RemoveAndHide.zs**
- Cleanup for **Armor** and **Tool Tooltips** via Loop function
- Removed double Chest recipes


**Wood  (Log to Planks) rework:**
- Wood recipes are now created using an array loop 
     - this makes it clearer for new log / plank recipes without having to create multiple lines of _**recipes.remove**_ and **_recipes.addShapeless_**






