### PR TITLE
Hydrated Tin Dust Recipe Fix

### DIFF
--- a/scripts/expert/IndustrialCraft2.zs
+++ b/scripts/expert/IndustrialCraft2.zs
@@ -74,5 +74,8 @@ recipes.remove(<ic2:nuclear:2>*9);
 mods.thermalexpansion.Factorizer.removeRecipeSplit(<enderio:item_material:28>);
 mods.appliedenergistics2.Grinder.removeRecipe(<minecraft:ender_pearl>);
 
+#Hydrated Tin Dust
+recipes.remove(<ic2:dust:29>);
+recipes.addShapeless("ic2_hydrated_tin_dust_liquid_fix", <ic2:dust:29>, [<ore:dustTin>, <liquid:water> * 1000]);
 
 print("Initialized 'IndustrialCraft2.zs'");

--- a/scripts/normal/IC2.zs
+++ b/scripts/normal/IC2.zs
@@ -11,4 +11,8 @@ Factorizer.removeRecipeSplit(<enderio:item_material:28>);
 mods.appliedenergistics2.Grinder.removeRecipe(<minecraft:ender_pearl>);
 recipes.removeByRecipeName("enderio:ender_dust");
 
+#Hydrated Tin Dust
+recipes.remove(<ic2:dust:29>);
+recipes.addShapeless("ic2_hydrated_tin_dust_liquid_fix", <ic2:dust:29>, [<ore:dustTin>, <liquid:water> * 1000]);
+
 print("Initialized 'IC2.zs'");


### PR DESCRIPTION
**Fixed:**
 - Hydrated Tin Dust can now be crafted with any tank that has 1000mb in it without consuming the container