### PR TITLE
IC2 10k Coolant Cell and Hydrated Tin Dust Recipe Fix

### DIFF
--- a/scripts/expert/IndustrialCraft2.zs
+++ b/scripts/expert/IndustrialCraft2.zs
@@ -74,8 +74,4 @@ recipes.remove(<ic2:nuclear:2>*9);
 mods.thermalexpansion.Factorizer.removeRecipeSplit(<enderio:item_material:28>);
 mods.appliedenergistics2.Grinder.removeRecipe(<minecraft:ender_pearl>);
 
-#Hydrated Tin Dust
-recipes.remove(<ic2:dust:29>);
-recipes.addShapeless("ic2_hydrated_tin_dust_liquid_fix", <ic2:dust:29>, [<ore:dustTin>, <liquid:water> * 1000]);
-
 print("Initialized 'IndustrialCraft2.zs'");

--- a/scripts/expert/ThermalExpansion.zs
+++ b/scripts/expert/ThermalExpansion.zs
@@ -32,8 +32,8 @@ recipes.addShaped(<thermalexpansion:dynamo>, [[null, <ic2:crafting:18>, null], [
 #Augment: Lapidary Calibration
 recipes.removeByRecipeName("thermalexpansion:augment_39");
 recipes.addShaped(<thermalexpansion:augment:720>, [
-    [null, <thermalfoundation:material:293>, null], 
-    [<thermalfoundation:material:294>, <thermalfoundation:material:515>, <thermalfoundation:material:294>], 
+    [null, <thermalfoundation:material:293>, null],
+    [<thermalfoundation:material:294>, <thermalfoundation:material:515>, <thermalfoundation:material:294>],
     [null, <minecraft:emerald>, null]
     ]);
 
@@ -134,5 +134,13 @@ recipes.remove(<ic2:misc_resource:1> * 2);
 
 #Copper Block to Ingots
 recipes.addShapeless(<thermalfoundation:material:128> * 9, [<thermalfoundation:storage>]);
+
+#Hydrated Tin Dust
+recipes.remove(<ic2:dust:29>);
+mods.thermalexpansion.Transposer.addFillRecipe(<ic2:dust:29>, <thermalfoundation:material:65>, <liquid:water> * 1000, 1000);
+
+#10k Coolant Cell
+recipes.remove(<ic2:heat_storage>);
+mods.thermalexpansion.Transposer.addFillRecipe(<ic2:heat_storage>.withTag({advDmg: 0}), <thermalfoundation:material:321> * 4, <liquid:ic2coolant> * 1000, 2000);
 
 print("Initialized 'ThermalExpansion.zs'");

--- a/scripts/normal/ThermalExpansion.zs
+++ b/scripts/normal/ThermalExpansion.zs
@@ -14,4 +14,13 @@ mods.thermalexpansion.Pulverizer.removeRecipe(<minecraft:ender_pearl>);
 #Copper Block to Ingots
 recipes.addShapeless(<thermalfoundation:material:128> * 9, [<thermalfoundation:storage>]);
 
+#Hydrated Tin Dust
+recipes.remove(<ic2:dust:29>);
+mods.thermalexpansion.Transposer.addFillRecipe(<ic2:dust:29>, <thermalfoundation:material:65>, <liquid:water> * 1000, 1000);
+
+#10k Coolant Cell
+recipes.remove(<ic2:heat_storage>);
+mods.thermalexpansion.Transposer.addFillRecipe(<ic2:heat_storage>.withTag({advDmg: 0}), <thermalfoundation:material:321> * 4, <liquid:ic2coolant> * 1000, 2000);
+
+
 print("Initialized 'ThermalExpansion.zs'");


### PR DESCRIPTION
**Fixed:**
 - Fluid containers that are stackable from OpenBlocks and IndustrialCraft 2 can be duplicated with FluidStack recipes