### PR TITLE
Blacklisted Zombie in Mob Duplicator due to Duping

### DIFF
--- a/config/industrialforegoing.cfg
+++ b/config/industrialforegoing.cfg
@@ -356,6 +356,7 @@ machines {
     mob_duplicator {
         # A list of blacklisted entities like minecraft:creeper [default: ]
         S:blacklistedEntities <
+	minecraft:zombie
          >
 
         # Set to true to enable exact copy in the Mob Duplicator. [default: false]


### PR DESCRIPTION
Changed:
 - Zombies cannot be spawned in the mob duplicator as they can be duplicated with items in their hands