### PR TITLE
Hide extra coal coke blocks and fix quest rewards

### DIFF
--- a/config/ftbquests/expert/reward_tables/bdc02cee.snbt
+++ b/config/ftbquests/expert/reward_tables/bdc02cee.snbt
@@ -6,7 +6,7 @@
 			id: "forestry:can",
 			tag: {
 				Fluid: {
-					FluidName: "ic2creosote",
+					FluidName: "creosote",
 					Amount: 1000
 				}
 			},
@@ -15,6 +15,6 @@
 		count: 8
 	},
 	{
-		item: "railcraft:generic 1 6"
+		item: "thermalfoundation:storage_resource 1 1"
 	}]
 }

--- a/config/ftbquests/normal/reward_tables/bdc02cee.snbt
+++ b/config/ftbquests/normal/reward_tables/bdc02cee.snbt
@@ -6,7 +6,7 @@
 			id: "forestry:can",
 			tag: {
 				Fluid: {
-					FluidName: "ic2creosote",
+					FluidName: "creosote",
 					Amount: 1000
 				}
 			},
@@ -15,6 +15,6 @@
 		count: 8
 	},
 	{
-		item: "railcraft:generic 1 6"
+		item: "thermalfoundation:storage_resource 1 1"
 	}]
 }

--- a/scripts/expert/Oredict.zs
+++ b/scripts/expert/Oredict.zs
@@ -26,6 +26,8 @@ rh(<railcraft:coke_oven_red>);
 rh(<railcraft:fuel_coke>);
 rh(<ic2:coke>);
 rh(<immersiveengineering:material:6>);
+rh(<immersiveengineering:stone_decoration:3>);
+rh(<railcraft:generic:6>);
 
 #Coke
 mods.immersiveengineering.CokeOven.removeRecipe(<immersiveengineering:material:6>);

--- a/scripts/normal/Oredict.zs
+++ b/scripts/normal/Oredict.zs
@@ -32,6 +32,8 @@ rh(<railcraft:coke_oven_red>);
 rh(<railcraft:fuel_coke>);
 rh(<ic2:coke>);
 rh(<immersiveengineering:material:6>);
+rh(<immersiveengineering:stone_decoration:3>);
+rh(<railcraft:generic:6>);
 
 #Coke
 mods.immersiveengineering.CokeOven.removeRecipe(<immersiveengineering:material:6>);


### PR DESCRIPTION
Fixes #197. I do not bother unifying the ore dictionaries for coal coke because the ONLY way to get the railcraft coal coke is the quest reward. Once the quest reward is fixed there is no way to get it, so I've also hidden it from JEI.

Similarly did the same fix for the creosote reward, since the original reward was ic2 creosote which was only obtainable through that quest.
