### PR TITLE
Regen Foamfix Config to fix Railcraft Errors

### DIFF
--- a/config/foamfix.cfg
+++ b/config/foamfix.cfg
@@ -68,7 +68,7 @@ coremod {
     B:patchChunkSerialization=true
 
     # Replaces the default BlockState/ExtendedBlockState implementations with a far more memory-efficient variant. [default: true]
-    B:smallPropertyStorage=false
+    B:smallPropertyStorage=true
 }
 
 
@@ -81,7 +81,6 @@ debug {
 experimental {
     # Optimizes the backing map for EntityDataManager, saving memory *and* CPU time! May cause issues, however - please test and report back! [default: false]
     B:fasterEntityDataManager=false
-    B:parallelModelBaking=true
 
     # Unpacks all baked quads. Increases RAM usage, but might speed some things up. [default: false]
     B:unpackBakedQuads=false
@@ -91,7 +90,6 @@ experimental {
 general {
     # Enable deduplication of redundant objects in memory. [default: true]
     B:deduplicate=true
-    B:patchChunkSerialization=true
 }
 
 
@@ -102,6 +100,10 @@ ghostbuster {
     # The amount of time FoamFix should wait for a world to be deemed non-unloaded. [default: 60, range: 10-3600]
     I:checkNonUnloadedWorldTimeout=60
 
+    # Custom patch rules. Format: 'className;methodName;accessAloadPos;posAloadPos;radius'. An AloadPos is the position of the argument in the method - 1 for the first one, 2 for the second one, ...; the radius determines how many blocks have to be around the method for no early return. Untested - please use with care.
+    S:customPatchRulesRadius <
+     >
+
     # Wrap ChunkProviderServers to be able to provide the /ghostbuster command for debugging ghost chunkloads. [default: false]
     B:enableDebuggingWrapper=false
 
@@ -110,6 +112,15 @@ ghostbuster {
 
     # Should beds be prevented from ghost chunkloading? [default: true]
     B:patchBeds=true
+
+    # Should BoP grass be prevented from ghost chunkloading? [default: true]
+    B:patchBopGrass=true
+
+    # Should farmland be prevented from ghost chunkloading? [default: true]
+    B:patchFarmland=true
+
+    # Should fluids be prevented from ghost chunkloading? [default: true]
+    B:patchFluids=true
 
     # Should the /ghostbuster debugger show neighbor updates? [default: false]
     B:wrapperShowsNeighborUpdates=false


### PR DESCRIPTION
This should fix the crashes that can occur, regarding not rendering Railcraft Items in JEI searches.

The Config is now a newly generated foamfix config, where nothing is tweaked