### PR TITLE
Draconic Evolution Config Tweaks

### DIFF
--- a/config/brandon3055/DraconicEvolution.cfg
+++ b/config/brandon3055/DraconicEvolution.cfg
@@ -195,7 +195,7 @@ Tweaks {
     B:disableGuardianCrystalRespawn=false
 
     # If true, this will disable the massive reactor explosion and replace it with a much smaller one.
-    B:disableLargeReactorBoom=true
+    B:disableLargeReactorBoom=false
 
     # This will disable loot cores (The "Blobs" of items dropped by the tools.).
     B:disableLootCores=false
@@ -246,7 +246,7 @@ Tweaks {
 
     # Set to false if you dont want the guardian to be able to kill creative players.
     # Alternatively... Just dont poke the guardian if you dont want to die!
-    B:guardianCanKillCreative=true
+    B:guardianCanKillCreative=false
 
     # When true, everything is just a little harder. (Currently only effects recipes but that will probably change in the future)
     B:hardMode=false


### PR DESCRIPTION
- Reactor explodes like in 1.7
- Creative players cannot be killed by creative players anymore