### PR TITLE
Immersive engineering crusher takes ages to process ores, Netherending Ores.cfg

### DIFF
--- a/config/Netherending Ores.cfg
+++ b/config/Netherending Ores.cfg
@@ -642,10 +642,10 @@ recipes {
 
         "immersive engineering" {
             # Multiplies the crusher time taken at the 2x recipe multiplier by this amount. [range: 0.001 ~ 1000.0, default: 1.8]
-            S:"Crusher 2x recipe multiplier time multiplier"=1.8
+            S:"Crusher 2x recipe multiplier time multiplier"=1.0
 
             # Multiplies the crusher time taken at the 3x recipe multiplier by this amount. [range: 0.001 ~ 1000.0, default: 2.5]
-            S:"Crusher 3x recipe multiplier time multiplier"=2.5
+            S:"Crusher 3x recipe multiplier time multiplier"=1.0
         }
 
         ##########################################################################################################


### PR DESCRIPTION
Immersive engineering crusher takes ages to process ores. Setting these two config options to 1.0 fixes that problem.

bbharier's  suggestion in:
https://github.com/EnigmaticaModpacks/Enigmatica2Expert/issues/1841